### PR TITLE
Refactor apg module and surrounding Flask code

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,17 +1,23 @@
 from flask import Flask
+from pathlib import Path
 
 FILE_FOLDER = r"/Users/jeff/tmp"  # local folder to store uploaded/generated files
-ALLOWED_EXTENSIONS = {"txt", "wav"}  # txt for phrase_file, wav for mix file
+PHRASEFILE_EXTENSIONS = {".txt"}  # txt for phrase_file, wav for mix file
+SOUNDFILE_EXTENSIONS = {".wav"}  # txt for phrase_file, wav for mix file
 MAX_CONTENT_LENGTH = 50 * 1024 * 1024  # max file upload file size ~ 50MB
 
 app = Flask(__name__)
 
 app.config["FILE_FOLDER"] = FILE_FOLDER
-app.config["ALLOWED_EXTENSIONS"] = ALLOWED_EXTENSIONS
+app.config["PHRASEFILE_EXTENSIONS"] = PHRASEFILE_EXTENSIONS
+app.config["SOUNDFILE_EXTENSIONS"] = SOUNDFILE_EXTENSIONS
 app.config["MAX_CONTENT_LENGTH"] = MAX_CONTENT_LENGTH
 
 from app import views
 from app import admin_views
+
+# Config app for file upload location, and create dir if needed
+Path(app.config["FILE_FOLDER"]).mkdir(parents=True, exist_ok=True)
 
 import logging
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -14,4 +14,9 @@ from app import views
 from app import admin_views
 
 import logging
-logging.basicConfig(filename='flask.log', level=logging.WARN, format=f'%(asctime)s %(levelname)s %(name)s %(threadName)s : %(message)s')
+
+logging.basicConfig(
+    filename="flask.log",
+    level=logging.WARN,
+    format=f"%(asctime)s %(levelname)s %(name)s %(threadName)s : %(message)s",
+)

--- a/app/apg.py
+++ b/app/apg.py
@@ -12,19 +12,19 @@ from pydub import AudioSegment
 class Apg:
     def __init__(
         self,
-        phrase_file: str,
+        phrase_file: Path,
         to_mix: bool = False,
-        sound_file: str = "",
+        sound_file: Path = None,
         attenuation: int = 0,
     ):
         """Initialize class instance"""
-        self.phrase_file = Path(phrase_file)  # Input file to generate speech segments
+        self.phrase_file = phrase_file  # Input file to generate speech segments
         self.speech_file = None  # Generated speech/silence
         self.mix_file = None  # Mixed speeech/sound
-        self.to_mix = bool(to_mix)  # Specifies if mixing will take place
-        self.sound_file = Path(sound_file)  # File with which to mix generated speech
-        self.attenuation = int(attenuation)  # Attenuation value, if mixing
-        self.save_file = str(Path(phrase_file).parent / Path(phrase_file).stem) + ".mp3"
+        self.to_mix = to_mix  # Specifies if mixing will take place
+        self.sound_file = sound_file  # File with which to mix generated speech
+        self.attenuation = attenuation  # Attenuation value, if mixing
+        self.save_file = str(phrase_file.parent / phrase_file.stem) + ".mp3"
 
     def gen_speech(self):
         """Generate a combined speech file, made up of gTTS-generated speech
@@ -49,7 +49,7 @@ class Apg:
                 if len(phrase) == 0:
                     print("Error: gTTS requires non-empty text to process.")
                     print("File: ", self.phrase_file)
-                    print("Line number: ", num_rows)
+                    print("Line: ", line)
                     sys.exit()
 
                 # Each speech snippet generated from gTTS is saved locally

--- a/app/apg.py
+++ b/app/apg.py
@@ -90,3 +90,11 @@ class Apg:
         return (segment1).overlay(
             (segment2_normalized - float(seg2_atten)).fade_in(fadein).fade_out(fadeout)
         )
+
+    def invoke(self):
+        if self.to_mix == True:
+            bkgnd = AudioSegment.from_file(self.sound_file, format="wav")
+            self.mix_file = self.mix(self.speech_file, bkgnd, self.attenuation)
+            self.mix_file.export(self.save_file, format="mp3")
+        else:
+            self.speech_file.export(self.save_file, format="mp3")

--- a/app/apg.py
+++ b/app/apg.py
@@ -92,6 +92,7 @@ class Apg:
         )
 
     def invoke(self):
+        self.gen_speech()
         if self.to_mix == True:
             bkgnd = AudioSegment.from_file(self.sound_file, format="wav")
             self.mix_file = self.mix(self.speech_file, bkgnd, self.attenuation)

--- a/app/views.py
+++ b/app/views.py
@@ -61,6 +61,7 @@ def setvals():
                 )  # CONVERT ME TO PATHLIB!
                 sound_file.close()
 
+        # Instantiate Apg object with params passed in from HTML form
         if to_mix:
             A = apg.Apg(
                 os.path.join(app.config["FILE_FOLDER"], phrase_savefile),
@@ -73,11 +74,8 @@ def setvals():
                 os.path.join(app.config["FILE_FOLDER"], phrase_savefile)
             )  # CONVERT ME TO PATHLIB!
 
-        A.gen_speech()
+        # Generate mixed sound file from speech, and serve in browser
         A.invoke()
-
-        # Refresh page and direct broswer to save/open resultant file
-        # (see get_file endpoint directly below)
         return redirect(url_for("get_file", path=Path(A.save_file).name))
 
 

--- a/app/views.py
+++ b/app/views.py
@@ -5,13 +5,10 @@ from flask import (
     render_template,
     request,
     redirect,
-    jsonify,
     send_from_directory,
     url_for,
 )
 from werkzeug.utils import secure_filename
-
-from pydub import AudioSegment
 
 from app import app
 import app.apg as apg
@@ -26,10 +23,8 @@ def allowed_file(filename):
 
 @app.route("/setvals", methods=("GET", "POST"))
 def setvals():
-    # All requests other than POST (i.e. GET) are re-shown the input form.
-    # Data from the form's 'submit' button results in a POST, and will be
-    # processed by the audio_program_generator (apg) code.
 
+    # All requests other than POST (i.e. GET) are re-shown the input form.
     if not request.method == "POST":
         return render_template("public/setvals2.html")
     else:
@@ -40,7 +35,10 @@ def setvals():
         if not allowed_file(phrase_file.filename):
             return render_template("public/setvals.html")
         else:
+            # Config app for file upload ocaion, and create dir if needed
             Path(app.config["FILE_FOLDER"]).mkdir(parents=True, exist_ok=True)
+
+            # Save the phrase file to local file upload dir
             phrase_savefile = secure_filename(phrase_file.filename)
             phrase_file.save(
                 os.path.join(app.config["FILE_FOLDER"], phrase_savefile)
@@ -48,13 +46,19 @@ def setvals():
             phrase_file.close()
 
         if to_mix:
-            attenuation = int(request.form.get("attenuation"))
+            attenuation = (
+                int(request.form.get("attenuation"))
+                if request.form.get("attenuation")
+                else 0
+            )
             sound_file = request.files["sound_file"]
             if not allowed_file(sound_file.filename):
                 return render_template("public/setvals.html")
             else:
                 sound_savefile = secure_filename(sound_file.filename)
-                sound_file.save(os.path.join(app.config["FILE_FOLDER"], sound_savefile))  # CONVERT ME TO PATHLIB!
+                sound_file.save(
+                    os.path.join(app.config["FILE_FOLDER"], sound_savefile)
+                )  # CONVERT ME TO PATHLIB!
                 sound_file.close()
 
         if to_mix:
@@ -65,22 +69,18 @@ def setvals():
                 attenuation,
             )  # CONVERT ME TO PATHLIB!
         else:
-            A = apg.Apg(os.path.join(app.config["FILE_FOLDER"], phrase_savefile))  # CONVERT ME TO PATHLIB!
+            A = apg.Apg(
+                os.path.join(app.config["FILE_FOLDER"], phrase_savefile)
+            )  # CONVERT ME TO PATHLIB!
 
         A.gen_speech()
+        A.invoke()
 
-        # TODO: abstract out into the class?
-        if A.to_mix == True:
-            bkgnd = AudioSegment.from_file(A.sound_file, format="wav")
-            A.mix_file = A.mix(A.speech_file, bkgnd, A.attenuation)
-            A.mix_file.export(A.save_file, format="mp3")
-        else:
-            A.speech_file.export(A.save_file, format="mp3")
-        #breakpoint()
+        # Refresh page and direct broswer to save/open resultant file
+        # (see get_file endpoint directly below)
         return redirect(url_for("get_file", path=Path(A.save_file).name))
 
 
 @app.route("/get_file/<path:path>")
 def get_file(path):
-    """Download a file."""
     return send_from_directory(app.config["FILE_FOLDER"], path, as_attachment=True)


### PR DESCRIPTION
**The apg module was refactored to:**
- handle input more in line with the CLI version (meaning to say, input type checking must be done by surrounding code).
- implement new invoke() method which takes care of all the internal calls without exposing to calling code. Now all that needs to be done is send in a text file, and optional "mix" parameter with associated mix/sound file and attenuation value; the module then writes the output file to local disk (in case of CLI) or sends to browser for save/play.

**__init__.py was changed to split out app config for separate allowable phrase_file and sound_file types, and ran through Black.** 

**views.py was overhauled to:**
- provide input data to apg module similar to how latest CLI does it
- add new shutdown_server route for easier admin if process hangs